### PR TITLE
Add arm64 platform support to Docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -49,6 +52,7 @@ jobs:
           context: .
           push: true
           tags: ${{ env.APP_TAGS }}
+          platforms: linux/amd64,linux/arm64
 
       - name: Build and push docs
         uses: docker/build-push-action@v4
@@ -57,3 +61,4 @@ jobs:
           file: Dockerfile.docs
           push: true
           tags: ${{ env.DOC_TAGS }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Update GitHub action to create Docker images builds for both linux/amd64 and linux/arm64 architectures.

This was mainly so I could run the images on my Mac server. I've built the Docker image locally and it runs great. I would only need an ARM64 build of the containers so I can pull them with `docker compose`.