### PR TITLE
Add partial fuelling support

### DIFF
--- a/app/backend/src/db/migrations/20250815_00_partialFuel.ts
+++ b/app/backend/src/db/migrations/20250815_00_partialFuel.ts
@@ -1,0 +1,19 @@
+import { DataTypes } from "sequelize";
+import type { Migration } from "../index.js";
+
+export const up: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.addColumn("fuel_logs", "filled", {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+    defaultValue: true,
+  });
+  await queryInterface.addColumn("fuel_logs", "missed_last", {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+    defaultValue: false,
+  });
+}
+export const down: Migration = async ({ context: queryInterface }) => {
+  await queryInterface.removeColumn("fuel_logs", "filled");
+  await queryInterface.removeColumn("fuel_logs", "missed_last");
+}

--- a/app/backend/src/db/seeders/index.ts
+++ b/app/backend/src/db/seeders/index.ts
@@ -136,6 +136,8 @@ export const seedDemoData = async () => {
       fuelAmount: 35,
       cost: 50,
       notes: "Full tank",
+      filled: true,
+      missedLast: false
     },
     {
       vehicleId: vehicle1.id,
@@ -143,6 +145,8 @@ export const seedDemoData = async () => {
       odometer: 16000,
       fuelAmount: 32,
       cost: 48,
+      filled: true,
+      missedLast: false
     },
   ];
 
@@ -153,6 +157,8 @@ export const seedDemoData = async () => {
       odometer: 25600,
       fuelAmount: 40,
       cost: 60,
+      filled: true,
+      missedLast: false
     },
     {
       vehicleId: vehicle2.id,
@@ -161,6 +167,8 @@ export const seedDemoData = async () => {
       fuelAmount: 38,
       cost: 55,
       notes: "Filled at Shell",
+      filled: true,
+      missedLast: false
     },
   ];
 
@@ -177,6 +185,8 @@ export const seedDemoData = async () => {
       odometer: currentOdometer1,
       fuelAmount: parseFloat(fuelAmount.toFixed(2)),
       cost: parseFloat(cost.toFixed(2)),
+      filled: true,
+      missedLast: false
     });
   }
 
@@ -193,6 +203,8 @@ export const seedDemoData = async () => {
       odometer: currentOdometer2,
       fuelAmount: parseFloat(fuelAmount.toFixed(2)),
       cost: parseFloat(cost.toFixed(2)),
+      filled: true,
+      missedLast: false
     });
   }
 

--- a/app/backend/src/models/FuelLog.ts
+++ b/app/backend/src/models/FuelLog.ts
@@ -8,6 +8,8 @@ interface FuelLogAttributes {
   odometer: number;
   fuelAmount: number;
   cost: number;
+  filled: boolean;
+  missedLast: boolean;
   notes?: string;
 }
 
@@ -23,6 +25,8 @@ class FuelLog
   declare public odometer: number;
   declare public fuelAmount: number;
   declare public cost: number;
+  declare public filled: boolean;
+  declare public missedLast: boolean;
   declare public notes?: string;
 }
 
@@ -75,6 +79,16 @@ FuelLog.init(
           msg: "Fuel Amount must be greater than 0.",
         },
       },
+    },
+    filled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    },
+    missedLast: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
     },
     notes: {
       type: DataTypes.STRING,

--- a/app/backend/src/services/fuelLogService.ts
+++ b/app/backend/src/services/fuelLogService.ts
@@ -34,11 +34,15 @@ export const getFuelLogs = async (vehicleId: string) => {
       return { ...log.toJSON(), mileage: null };
     }
 
-    // find the previous log that serves as a starting point - either a full tank or after a gap
+    // find the previous full tank log that serves as a starting point
+    // a missed log acts as a barrier, preventing searching further back
     let startIndex = -1;
     for (let i = index - 1; i >= 0; i--) {
-      if (arr[i]?.filled || arr[i]?.missedLast) {
+      if (arr[i]?.filled) {
         startIndex = i;
+        break;
+      }
+      if (arr[i]?.missedLast) {
         break;
       }
     }

--- a/app/backend/src/services/fuelLogService.ts
+++ b/app/backend/src/services/fuelLogService.ts
@@ -29,16 +29,41 @@ export const getFuelLogs = async (vehicleId: string) => {
 
   // Calculate mileage
   return fuelLogs.map((log, index, arr) => {
-    if (index > 0) {
-      const prevLog = arr[index - 1];
-      if (!prevLog) {
-        return { ...log.toJSON(), mileage: null };
-      }
-      const distance = log.odometer - prevLog.odometer;
-      const mileage = distance / log.fuelAmount;
-      return { ...log.toJSON(), mileage: parseFloat(mileage.toFixed(2)) };
+    // mileage can only be calculated for a full tank and a previous log is needed
+    if (index === 0 || !log.filled) {
+      return { ...log.toJSON(), mileage: null };
     }
-    return { ...log.toJSON(), mileage: null };
+
+    // find the previous log that serves as a starting point - either a full tank or after a gap
+    let startIndex = -1;
+    for (let i = index - 1; i >= 0; i--) {
+      if (arr[i]?.filled || arr[i]?.missedLast) {
+        startIndex = i;
+        break;
+      }
+    }
+
+    // if there is no valid starting log, mileage can't be calculated
+    if (startIndex === -1) {
+      return { ...log.toJSON(), mileage: null };
+    }
+
+    const startLog = arr[startIndex]!;
+    const distance = log.odometer - startLog.odometer;
+
+    // sum all fuel added after the starting log (accounts for partial fills)
+    let totalFuel = 0;
+    for (let i = startIndex + 1; i <= index; i++) {
+      totalFuel += arr[i]!.fuelAmount;
+    }
+
+    // avoid division by zero and ensure distance is positive
+    if (totalFuel === 0 || distance <= 0) {
+      return { ...log.toJSON(), mileage: null };
+    }
+
+    const mileage = distance / totalFuel;
+    return { ...log.toJSON(), mileage: parseFloat(mileage.toFixed(2)) };
   });
 };
 

--- a/app/backend/src/services/fuelLogService.ts
+++ b/app/backend/src/services/fuelLogService.ts
@@ -30,7 +30,7 @@ export const getFuelLogs = async (vehicleId: string) => {
   // Calculate mileage
   return fuelLogs.map((log, index, arr) => {
     // mileage can only be calculated for a full tank and a previous log is needed
-    if (index === 0 || !log.filled) {
+    if (index === 0 || !log.filled || log.missedLast) {
       return { ...log.toJSON(), mileage: null };
     }
 

--- a/app/frontend/src/components/common/Checkbox.svelte
+++ b/app/frontend/src/components/common/Checkbox.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	let {
+		id,
+		checked = $bindable(),
+		icon = null,
+		label = undefined,
+		ariaLabel = '',
+		disabled = false,
+    inputClass = '',
+		onInput = undefined
+	} = $props();
+	const Icon = icon;
+</script>
+
+<div class="pl-2">
+  <input
+			{id}
+      type="checkbox"
+			bind:checked
+			class={`p-2 rounded-sm border border-gray-300 text-blue-500 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:focus:border-blue-400 dark:focus:ring-blue-400 ${inputClass}`}
+			aria-label={ariaLabel}
+			{disabled}
+			oninput={onInput}
+		/>
+  {#if label}
+    <label for={id} class="pl-1 text-lg text-gray-400">
+      {#if icon}
+        <Icon
+          class="inline-block h-5 w-5 text-gray-400 dark:text-gray-500"
+          aria-hidden="true"
+        />
+      {/if}
+      {label}
+    </label>
+  {/if}
+</div>

--- a/app/frontend/src/components/forms/FuelLogForm.svelte
+++ b/app/frontend/src/components/forms/FuelLogForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Button from '$components/common/Button.svelte';
+	import Checkbox from '$components/common/Checkbox.svelte';
 	import StatusBlock from '$components/common/StatusBlock.svelte';
 	import { env } from '$env/dynamic/public';
 	import { handleApiError } from '$lib/models/Error';
@@ -22,7 +23,9 @@
 		odometer: null,
 		fuelAmount: null,
 		cost: null,
-		notes: null
+		notes: null,
+    missedLast: false,
+    filled: true,
 	});
 
 	let status = $state<Status>({
@@ -71,7 +74,9 @@
 					odometer: '',
 					fuelAmount: '',
 					cost: '',
-					notes: ''
+					notes: '',
+          missedLast: false,
+          filled: true
 				});
 			} else {
 				const data = await response.json();
@@ -139,6 +144,23 @@
 			required={true}
 			ariaLabel="Fuel Cost"
 			inputClass="step-0.01"
+		/>
+	</div>
+
+  <div class="grid grid-flow-row grid-cols-2 gap-4">
+		<Checkbox
+			id="filled"
+			bind:checked={refill.filled}
+			icon={Fuel}
+			label="Tank Filled?"
+			ariaLabel="Tank Filled"
+		/>
+		<Checkbox
+			id="missedLast"
+			bind:checked={refill.missedLast}
+			icon={BadgeDollarSign}
+			label="Missed Last?"
+			ariaLabel="Previous Fuel Log Missed"
 		/>
 	</div>
 


### PR DESCRIPTION
This updates the mileage calculation algorithm to allow for partial fuel fill-ups and missed log entries.

The previous implementation assumed every log was a full tank and that there were no gaps in the data, which could lead to incorrect mileage values.

## Key Changes

- Mileage is now only calculated on logs where the tank is completely filled (`filled: true`).
- For logs marked as partial fills (`filled: false`), mileage is `null`. Their `fuelAmount` is accumulated and included in the calculation for the _next_ full tank.
- A log with `missedLast: true` serves as a "reset" point. It prevents calculation over an unknown distance and acts as a new, valid starting odometer for the subsequent caclulation.