### PR TITLE
Order fuel logs by odometer after date, for same-day refuels

### DIFF
--- a/app/backend/src/services/fuelLogService.ts
+++ b/app/backend/src/services/fuelLogService.ts
@@ -29,7 +29,7 @@ export const addFuelLog = async (vehicleId: string, fuelLogData: any) => {
 export const getFuelLogs = async (vehicleId: string) => {
   const fuelLogs = await db.query.fuelLogTable.findMany({
     where: (log, { eq }) => eq(log.vehicleId, vehicleId),
-    orderBy: (log, { asc }) => asc(log.date),
+    orderBy: (log, { asc }) => [asc(log.date), asc(log.odometer)],
   });
 
   // Calculate mileage

--- a/app/backend/src/services/vehicleService.ts
+++ b/app/backend/src/services/vehicleService.ts
@@ -16,7 +16,7 @@ export const addVehicle = async (vehicleData: any) => {
 const calculateOverallMileage = async (vehicleId: string) => {
   const fuelLogs = await db.query.fuelLogTable.findMany({
     where: (log, { eq }) => eq(log.vehicleId, vehicleId),
-    orderBy: (log, { asc }) => asc(log.date),
+    orderBy: (log, { asc }) => [asc(log.date), asc(log.odometer)],
   });
 
   if (fuelLogs.length < 2) return null;
@@ -95,7 +95,7 @@ export const getAllVehicles = async () => {
     vehicles.map(async (vehicle) => {
       const latestLog = await db.query.fuelLogTable.findFirst({
         where: (log, { eq }) => eq(log.vehicleId, vehicle.id),
-        orderBy: (log, { desc }) => desc(log.date),
+        orderBy: (log, { desc }) => [log(logs.date), desc(log.odometer)],
         columns: {
           odometer: true,
         },
@@ -174,7 +174,7 @@ export const getVehicleById = async (id: string) => {
   // Get current odometer from latest fuel log
   const latestFuelLog = await db.query.fuelLogTable.findFirst({
     where: (log, { eq }) => eq(log.vehicleId, id),
-    orderBy: (log, { desc }) => desc(log.date),
+    orderBy: (log, { desc }) => [desc(log.date), desc(log.odometer)],
     columns: {
       odometer: true,
     },


### PR DESCRIPTION
When refueling several times per day, fuels logs were not properly sorted.

I've added a second order by clause where it's necessary.