### PR TITLE
fix(vehicle): preserve image on edit; stop sending image=null

### DIFF
--- a/src/lib/components/feature/vehicle/VehicleForm.svelte
+++ b/src/lib/components/feature/vehicle/VehicleForm.svelte
@@ -53,7 +53,7 @@
 	const { form: formData, enhance } = form;
 
 	$effect(() => {
-		if (data) formData.set({ ...data, image: null });
+		if (data) formData.set({ ...data });
 	});
 </script>
 


### PR DESCRIPTION
Root cause: When editing a vehicle, the form initialized with `image: null`, which cleared the image on update.

Fix: Preserve the existing `image` in form initialization; only update it when a new file is uploaded.

Change:
- src/lib/components/feature/vehicle/VehicleForm.svelte

Validation:
- Local unit tests pass
- Svelte build succeeds

Closes #137