### PR TITLE
capitalize VIN and license plate automatically

### DIFF
--- a/src/lib/domain/vehicle.ts
+++ b/src/lib/domain/vehicle.ts
@@ -62,11 +62,13 @@ export const vehicleSchema = z.object({
 		.string()
 		.min(2, 'It must be more than 1 character.')
 		.max(50, 'It must be less than 50 characters.')
+		.transform((val) => val.toUpperCase())
 		.nullable(),
 	vin: z
 		.string()
 		.min(2, 'It must be more than 1 character.')
 		.max(50, 'It must be less than 50 characters.')
+		.transform((val) => val.toUpperCase())
 		.nullable(),
 	color: z
 		.string()


### PR DESCRIPTION
I added a line that automatically capitalizes the VIN and license plate number.

Testing, linting, and formatting were successful.
Attached is a video to show that it works.

https://github.com/user-attachments/assets/01e562a1-8539-4ad1-bdb6-26bd99078e12